### PR TITLE
Try to fix Windows build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,7 @@ test:
     {% set hdf5_unix_cmds = [
         "h5c++",
         "h5cc",
+        "h5perf_serial",
         "h5redeploy"
     ] %}
     {% for each_hdf5_unix_cmd in hdf5_unix_cmds %}
@@ -62,7 +63,6 @@ test:
         "h5jam",
         "h5ls",
         "h5mkgrp",
-        "h5perf_serial",
         "h5repack",
         "h5repart",
         "h5stat",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
     - test_Makefile.in.patch
 
 build:
-  number: 1
+  number: 2
   features:
     - vc9     # [win and py27]
     - vc10    # [win and py34]
@@ -40,12 +40,20 @@ test:
     - python    # [win]
 
   commands:
+    # Verify UNIX CLI tools.
+    {% set hdf5_unix_cmds = [
+        "h5c++",
+        "h5cc",
+        "h5redeploy"
+    ] %}
+    {% for each_hdf5_unix_cmd in hdf5_unix_cmds %}
+    - command -v {{ each_hdf5_unix_cmd }}   # [unix]
+    {% endfor %}
+
     # Verify CLI tools.
     {% set hdf5_cmds = [
         "gif2h5",
         "h52gif",
-        "h5c++",
-        "h5cc",
         "h5copy",
         "h5debug",
         "h5diff",
@@ -55,7 +63,6 @@ test:
         "h5ls",
         "h5mkgrp",
         "h5perf_serial",
-        "h5redeploy",
         "h5repack",
         "h5repart",
         "h5stat",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,9 @@ requirements:
     - zlib
 
 test:
+  requires:
+    - python    # [win]
+
   commands:
     # Verify CLI tools.
     {% set hdf5_cmds = [


### PR DESCRIPTION
Fixes https://github.com/conda-forge/hdf5-feedstock/issues/1

Tries to fix the Windows build. In particular, the testing section seems not to be working because HDF5 can't be installed. Here we try to fix it by making sure the right feature is enabled (`vc*`) by installing Python. Hopefully, it ends up being the correct Python version.