### PR TITLE
WIP: Bump HDF5 1.8.15.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,5 @@
-{% set version = "1.8.15" %}
+{% set version = "1.8.15.1" %}
+{% set version_str = "-patch".join(version.rsplit(".", 1)) %}
 
 package:
   name: hdf5
@@ -6,8 +7,8 @@ package:
 
 source:
   fn: hdf5-{{version}}.tar.gz
-  url: https://www.hdfgroup.org/ftp/HDF5/releases/hdf5-{{ version }}/src/hdf5-{{ version }}.tar.gz
-  md5: 03cccb5b33dbe975fdcd8ae9dc021f24
+  url: https://www.hdfgroup.org/ftp/HDF5/releases/hdf5-{{ version_str }}/src/hdf5-{{ version_str }}.tar.gz
+  md5: 4467c25ed9c0b126b194a4d9d66c29ac
   patches:
     # Patches the test suite to skip the `cache` test.
     # This test has been found to rather resource intensive.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.8.16" %}
+{% set version = "1.8.15" %}
 
 package:
   name: hdf5
@@ -7,7 +7,7 @@ package:
 source:
   fn: hdf5-{{version}}.tar.gz
   url: https://www.hdfgroup.org/ftp/HDF5/releases/hdf5-{{ version }}/src/hdf5-{{ version }}.tar.gz
-  md5: b8ed9a36ae142317f88b0c7ef4b9c618
+  md5: 03cccb5b33dbe975fdcd8ae9dc021f24
   patches:
     # Patches the test suite to skip the `cache` test.
     # This test has been found to rather resource intensive.
@@ -20,7 +20,7 @@ source:
     - test_Makefile.in.patch
 
 build:
-  number: 3
+  number: 0
   features:
     - vc9     # [win and py27]
     - vc10    # [win and py34]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
     - test_Makefile.in.patch
 
 build:
-  number: 0
+  number: 10
   features:
     - vc9     # [win and py27]
     - vc10    # [win and py34]


### PR DESCRIPTION
Depends on this PR ( https://github.com/conda-forge/hdf5-feedstock/pull/18 )
Depends on this PR ( https://github.com/conda-forge/hdf5-feedstock/pull/19 )

This bumps up the build number of HDF5 1.8.15.1 significantly so that it is higher than the HDF5 1.8.15.1 package in `defaults`. This is important as the `defaults` version seems to cause some problems. One of these problems affects our build of `libnetcdf`. See this PR ( https://github.com/conda-forge/libnetcdf-feedstock/pull/1 ).