### PR TITLE
Use the toolchain

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+# FIXME: This is a hack to make sure the environment is activated.
+# The reason this is required is due to the conda-build issue
+# mentioned below.
+#
+# https://github.com/conda/conda-build/issues/910
+#
+source activate "${CONDA_DEFAULT_ENV}"
+
+if [ "$(uname)" == "Darwin" ]
+then
+    export CXX="${CXX} -stdlib=libc++"
+fi
+
 ./configure --prefix="${PREFIX}" \
     --enable-linux-lfs \
     --with-zlib="${PREFIX}" \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
     - test_Makefile.in.patch
 
 build:
-  number: 0
+  number: 1
   features:
     - vc9     # [win and py27]
     - vc10    # [win and py34]
@@ -29,7 +29,9 @@ build:
 
 requirements:
   build:
-    - python    # [win]
+    - toolchain
+    - python         # [win]
+    - libtool        # [unix]
     - cmake >=3.1
     - zlib 1.2*
   run:
@@ -88,6 +90,11 @@ test:
     - test -f $PREFIX/lib/lib{{ each_hdf5_lib }}.so                          # [linux]
     - if not exist %PREFIX%\\Library\\lib\\{{ each_hdf5_lib }}.lib exit 1    # [win]
     - if not exist %PREFIX%\\Library\\bin\\{{ each_hdf5_lib }}.dll exit 1    # [win]
+    {% endfor %}
+
+    # Inspect linkages of HDF5.
+    {% for each_hdf5_lib in hdf5_libs %}
+    - otool -L $PREFIX/lib/lib{{ each_hdf5_lib }}.dylib                      # [osx]
     {% endfor %}
 
 about:


### PR DESCRIPTION
Try switching over to using the toolchain to build HDF5. This should result in binaries using `libc++` on Mac.