### PR TITLE
Add @gillins

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -107,5 +107,6 @@ about:
 extra:
   recipe-maintainers:
     - jakirkham
+    - gillins
     - groutr
     - ocefpaf


### PR DESCRIPTION
This add @gillins as a maintainer on the `hdf5` feedstock.

I figured I would go ahead and add you now as you have been so helpful. Given your interest in getting this working, it feels silly to restrict your ability to make substantive change when we need it. Hope that is ok.