### PR TITLE
Unpin `conda-build`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
 
       conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
+      conda install --yes conda-build jinja2 anaconda-client
       conda config --add channels conda-forge
       
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
     - test_Makefile.in.patch
 
 build:
-  number: 1
+  number: 2
   features:
     - vc9     # [win and py27]
     - vc10    # [win and py34]


### PR DESCRIPTION
Fixes https://github.com/conda-forge/hdf5-feedstock/issues/23

This PR unpins `conda-build` on Travis CI. The mismatch between functionality regarding environments and their activation in `conda` and `conda-env` vs `conda-build` is causing some rather strange problems. In particular, it is result in symlink files getting packaged with the binaries in some cases. Switching to a newer version of `conda-build` fixes this problem as it properly ignores these activation files. Thus we unpin `conda-build` and bump the build number so we can get a new package out without the activation scripts included.

cc @gillins @david-murr