### PR TITLE
Don't use DYLD_FALLBACK_LIBRARY_PATH

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,7 +11,7 @@ source activate "${CONDA_DEFAULT_ENV}"
 if [ "$(uname)" == "Darwin" ]
 then
     export CXX="${CXX} -stdlib=libc++"
-    export DYLD_FALLBACK_LIBRARY_PATH=$PREFIX/lib
+    export LDFLAGS="-Wl,-rpath,$PREFIX/lib"
 fi
 
 export LIBRARY_PATH="${PREFIX}/lib"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
     - test_Makefile.in.patch
 
 build:
-  number: 4
+  number: 5
   features:
     - vc9     # [win and py27]
     - vc10    # [win and py34]

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -13,16 +13,7 @@ h5c++ -show
 h5c++ h5tutr_cmprss.cpp -o h5tutr_cmprss
 ./h5tutr_cmprss
 
-# Test Fortran compiler. For this we need to set DYLD_FALLBACK_LIBRARY_PATH to
-# make sure libgfortran gets picked up. Ideally this shouldn't be needed, but
-# this is how the gfortran compiler works in conda - see:
-#
-#   https://github.com/ContinuumIO/anaconda-issues/issues/739
-#
-# for more details.
-
-export DYLD_FALLBACK_LIBRARY_PATH=${CONDA_PREFIX}/lib
-
+# Test Fortran compiler
 echo "Testing h5fc"
 h5fc -show
 h5fc h5_cmprss.f90 -o h5_cmprss


### PR DESCRIPTION
... because it doesn't work with recent versions of MacOS X due to the System Integrity Protection (see https://github.com/conda-forge/conda-forge.github.io/issues/238)