### PR TITLE
enable threadsafe and production

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -27,7 +27,9 @@ export LIBRARY_PATH="${PREFIX}/lib"
             --enable-threadsafe \
             --disable-hl \
             --enable-production \
-            --enable-unsupported
+            --enable-unsupported \
+            --disable-static \
+            --with-ssl
 
 make -j "${CPU_COUNT}"
 make check

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -26,7 +26,8 @@ export LIBRARY_PATH="${PREFIX}/lib"
             --with-default-plugindir="${PREFIX}/lib/hdf5/plugin" \
             --enable-threadsafe \
             --disable-hl \
-            --enable-production
+            --enable-production \
+            --enable-unsupported
 
 make -j "${CPU_COUNT}"
 make check

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -25,7 +25,6 @@ export LIBRARY_PATH="${PREFIX}/lib"
             --enable-fortran2003 \
             --with-default-plugindir="${PREFIX}/lib/hdf5/plugin" \
             --enable-threadsafe \
-            --disable-hl \
             --enable-production \
             --enable-unsupported \
             --disable-static \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -25,6 +25,7 @@ export LIBRARY_PATH="${PREFIX}/lib"
             --enable-fortran2003 \
             --with-default-plugindir="${PREFIX}/lib/hdf5/plugin" \
             --enable-threadsafe \
+            --disable-hl \
             --enable-production
 
 make -j "${CPU_COUNT}"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -23,7 +23,9 @@ export LIBRARY_PATH="${PREFIX}/lib"
             --enable-cxx \
             --enable-fortran \
             --enable-fortran2003 \
-            --with-default-plugindir="${PREFIX}/lib/hdf5/plugin"
+            --with-default-plugindir="${PREFIX}/lib/hdf5/plugin" \
+            --enable-threadsafe \
+            --enable-production
 
 make -j "${CPU_COUNT}"
 make check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
     - test_Makefile.in.patch
 
 build:
-  number: 6
+  number: 7
   features:
     - vc9     # [win and py27]
     - vc10    # [win and py34]


### PR DESCRIPTION
we use hdf5 in threaded processing, which can lead to segfaults if hdf is built without the threadsafe flag and the production flag
