### PR TITLE
Tweak download URL

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  fn: hdf5-{{version}}.tar.gz
+  fn: hdf5-{{ version }}.tar.gz
   url: https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-{{ version }}/src/hdf5-{{ version }}.tar.gz
   md5: 7d572f8f3b798a628b8245af0391a0ca
   patches:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,15 @@
 {% set version = "1.8.17" %}
 
+{% set maj_min_ver = ".".join(version.split(".")[:2]) %}
+
+
 package:
   name: hdf5
   version: {{ version }}
 
 source:
   fn: hdf5-{{ version }}.tar.gz
-  url: https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-{{ version }}/src/hdf5-{{ version }}.tar.gz
+  url: https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-{{ maj_min_ver }}/hdf5-{{ version }}/src/hdf5-{{ version }}.tar.gz
   md5: 7d572f8f3b798a628b8245af0391a0ca
   patches:
     # Patches the test suite to skip the `cache` test.


### PR DESCRIPTION
Seems new releases (and old ones) are showing up in a directory that separates releases by major minor version as well. So this updates the URL accordingly.