### PR TITLE
update_to_1.10.1

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,11 +16,10 @@ export LIBRARY_PATH="${PREFIX}/lib"
             --enable-fortran2003 \
             --with-default-plugindir="${PREFIX}/lib/hdf5/plugin" \
             --enable-threadsafe \
-            --enable-production \
+            --enable-build-mode=production \
             --enable-unsupported \
             --with-ssl
 
-#             --disable-static \
 make -j "${CPU_COUNT}"
 make check
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.8.18" %}
+{% set version = "1.10.1" %}
 
 {% set maj_min_ver = ".".join(version.split(".")[:2]) %}
 
@@ -10,16 +10,12 @@ package:
 source:
   fn: hdf5-{{ version }}.tar.gz
   url: https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-{{ maj_min_ver }}/hdf5-{{ version }}/src/hdf5-{{ version }}.tar.gz
-  md5: dd2148b740713ca0295442ec683d7b1c
+  sha256: 048a9d149fb99aaa1680a712963f5a78e9c43b588d0e79d55e06760ec377c172
   patches:
-    # Patches the test suite to skip the `cache` test.
+    # Patches the test suite to skip the cache, cache_image, and fheap tests
     # This test has been found to rather resource intensive.
     # In particular, it caused Travis CI's Mac builds to hang.
     # Given that we simply skip the test on all platforms.
-    # For more details, see the PR where this was proposed.
-    #
-    # https://github.com/conda-forge/staged-recipes/pull/199
-    #
     - test_Makefile.in.patch
     # Disable shared Fortran API building on OSX
     - osx_configure.patch  # [osx]

--- a/recipe/test_Makefile.in.patch
+++ b/recipe/test_Makefile.in.patch
@@ -1,13 +1,13 @@
-diff --git test/Makefile.in test/Makefile.in
-index 02ab570..f2b9889 100644
---- test/Makefile.in
-+++ test/Makefile.in
-@@ -1071,7 +1071,7 @@ check_SCRIPTS = $(TEST_SCRIPT)
- # These tests (fheap, btree2) are under development and are not used by
- # the library yet. Move them to the end so that their failure do not block
- # other current library code tests.
--TEST_PROG = testhdf5 lheap ohdr stab gheap cache cache_api \
-+TEST_PROG = testhdf5 lheap ohdr stab gheap cache_api \
-            pool accum hyperslab istore bittests dt_arith \
+--- hdf5-1.10.1.orig/test/Makefile.in	2017-04-27 15:56:04.000000000 -0300
++++ hdf5-1.10.1/test/Makefile.in	2017-06-14 15:33:31.096078745 -0300
+@@ -1381,8 +1381,8 @@
+ # As an exception, long-running tests should occur earlier in the list.
+ # This gives them more time to run when tests are executing in parallel.
+ TEST_PROG = testhdf5 \
+-           cache cache_api cache_image cache_tagging lheap ohdr stab gheap \
+-           evict_on_close farray earray btree2 fheap \
++           cache_api cache_tagging lheap ohdr stab gheap \
++           evict_on_close farray earray btree2 \
+            pool accum hyperslab istore bittests dt_arith page_buffer \
             dtypes dsets cmpd_dset filter_fail extend external efc objcopy links unlink \
-            big mtime fillval mount flush1 flush2 app_ref enum \
+            twriteorder big mtime fillval mount flush1 flush2 app_ref enum \


### PR DESCRIPTION
We should not updated the pinning yet! But I need this version in the channel to build the software against it and run some tests.