### PR TITLE
use pin_subpackage instead of x.y.* in mpi variant run_exports

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "1.10.4" %}
 {% set maj_min_ver = ".".join(version.split(".")[:2]) %}
-{% set build = 1001 %}
+{% set build = 1002 %}
 
 {# recipe-lint fails if mpi is undefined #}
 {% set mpi = mpi or 'nompi' %}
@@ -53,7 +53,7 @@ build:
   # at least not always
   {% if mpi != 'nompi' %}
   run_exports:
-    - hdf5 {{ maj_min_ver }}.* {{ mpi_prefix }}_*
+    - {{ pin_subpackage('hdf5') }} {{ mpi_prefix }}_*
   {% endif %}
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,7 @@ build:
   # at least not always
   {% if mpi != 'nompi' %}
   run_exports:
-    - {{ pin_subpackage('hdf5') }} {{ mpi_prefix }}_*
+    - {{ pin_subpackage('hdf5', max_pin='x.x.x') }} {{ mpi_prefix }}_*
   {% endif %}
 
 requirements:


### PR DESCRIPTION
for proper compatibility pinning

Note: due to a [bug in conda-build](https://github.com/conda/conda-build/pull/3264), run_exports (or runtime dependencies in general) discards build string information if hdf5 is present in pin_run_as_build. To get proper pinning of hdf5 with mpi, pin_run_as_build must be *disabled* for hdf5, with pinning applied in the recipe until the bug is fixed.