### PR TITLE
pin-compatible via run_exports

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "1.10.4" %}
 {% set maj_min_ver = ".".join(version.split(".")[:2]) %}
-{% set build = 1002 %}
+{% set build = 1003 %}
 
 {# recipe-lint fails if mpi is undefined #}
 {% set mpi = mpi or 'nompi' %}
@@ -51,10 +51,15 @@ build:
   # mpi builds require the right mpi
   # non-mpi builds *do not* appear to require non-mpi builds
   # at least not always
+
   {% if mpi != 'nompi' %}
-  run_exports:
-    - {{ pin_subpackage('hdf5', max_pin='x.x.x') }} {{ mpi_prefix }}_*
+  {% set build_pin = mpi_prefix + '_*' %}
+  {% else %}
+  {% set build_pin = '' %}
   {% endif %}
+
+  run_exports:
+    - {{ pin_subpackage('hdf5', max_pin='x.x.x') }} {{ build_pin }}
 
 requirements:
   build:


### PR DESCRIPTION
pin_run_as_build is conflicting with build string pinning due to a bug in conda-build (https://github.com/conda/conda-build/pull/3264).

so apply the same pinning here via run_exports instead to all builds of hdf5 (not just mpi builds). Then we can remove hdf5 from pin_run_as_build in conda-forge-pinning.


<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->