### PR TITLE
prioritize nompi via build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,9 +1,13 @@
 {% set version = "1.10.4" %}
 {% set maj_min_ver = ".".join(version.split(".")[:2]) %}
-{% set build = 1003 %}
+{% set build = 1004 %}
 
-{# recipe-lint fails if mpi is undefined #}
+# recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'nompi' %}
+{% if mpi == "nompi" %}
+# prioritize nompi via build number
+{% set build = build + 100 %}
+{% endif %}
 
 package:
   name: hdf5
@@ -31,11 +35,7 @@ source:
 
 build:
   number: {{ build }}
-  # Use track_features to express a preference for
-  # non-mpi variant
-  {% if mpi != 'nompi' %}
-  track_features:
-    - hdf5_{{ mpi }}
+  {% if mpi != "nompi" %}
   {% set mpi_prefix = "mpi_" + mpi %}
   {% else %}
   {% set mpi_prefix = "nompi" %}


### PR DESCRIPTION
instead of deprioritising mpi builds with track_features.

#90 *almost* works great. Deprioritizing via track_features works well as long as a given package has always depended on the given variant, or when that package has a variant scheme that *matches* that of hdf5.

However, there is a case where it doesn't work, and it just so happens to be the exact case that motivated me to build the parallel variants in the first place (fenics). And that's the case where an existing package has been building with serial hdf5 and wants to switch to parallel hdf5. The track_features deprioritization has a high enough priority that if a downstream package has ever been built against serial hdf5, new builds (and new versions) will never be installed unless parallel hdf5 is explicitly requested by the user. I discovered this in fenics, which builds and works great with parallel hdf5 now (yay!) but `conda install fenics` is getting the last version before parallel hdf5. `conda install fenics hdf5=*=mpi*` installs the latest build with parallel hdf5. If any other package has resulted in hdf5 with mpi, feincs with parallel hdf5 will be installed.

build number offsets, as we are using for new-compiler builds, seem to work in a more expected way, priority-wise for this kind of thing.

Changing this here doesn't affect what any downstream packages should do and doesn't require any rebuilds of packages other than this one. It should just work once these are released.

https://github.com/conda-forge/h5py-feedstock/pull/45 which adopts the same track_features approach here should wait for resolution here before being merged.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->