### PR TITLE
Add --enable-ros3-vfd build flag

### DIFF
--- a/.ci_support/linux_64_mpimpich.yaml
+++ b/.ci_support/linux_64_mpimpich.yaml
@@ -16,9 +16,17 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+libcurl:
+- '7'
 mpi:
 - mpich
+openssl:
+- 1.1.1
 pin_run_as_build:
+  libcurl:
+    max_pin: x
+  openssl:
+    max_pin: x.x.x
   zlib:
     max_pin: x.x
 target_platform:

--- a/.ci_support/linux_64_mpinompi.yaml
+++ b/.ci_support/linux_64_mpinompi.yaml
@@ -16,9 +16,17 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+libcurl:
+- '7'
 mpi:
 - nompi
+openssl:
+- 1.1.1
 pin_run_as_build:
+  libcurl:
+    max_pin: x
+  openssl:
+    max_pin: x.x.x
   zlib:
     max_pin: x.x
 target_platform:

--- a/.ci_support/linux_64_mpiopenmpi.yaml
+++ b/.ci_support/linux_64_mpiopenmpi.yaml
@@ -16,9 +16,17 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+libcurl:
+- '7'
 mpi:
 - openmpi
+openssl:
+- 1.1.1
 pin_run_as_build:
+  libcurl:
+    max_pin: x
+  openssl:
+    max_pin: x.x.x
   zlib:
     max_pin: x.x
 target_platform:

--- a/.ci_support/linux_aarch64_mpimpich.yaml
+++ b/.ci_support/linux_aarch64_mpimpich.yaml
@@ -22,9 +22,17 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+libcurl:
+- '7'
 mpi:
 - mpich
+openssl:
+- 1.1.1
 pin_run_as_build:
+  libcurl:
+    max_pin: x
+  openssl:
+    max_pin: x.x.x
   zlib:
     max_pin: x.x
 target_platform:

--- a/.ci_support/linux_aarch64_mpinompi.yaml
+++ b/.ci_support/linux_aarch64_mpinompi.yaml
@@ -22,9 +22,17 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+libcurl:
+- '7'
 mpi:
 - nompi
+openssl:
+- 1.1.1
 pin_run_as_build:
+  libcurl:
+    max_pin: x
+  openssl:
+    max_pin: x.x.x
   zlib:
     max_pin: x.x
 target_platform:

--- a/.ci_support/linux_aarch64_mpiopenmpi.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpi.yaml
@@ -22,9 +22,17 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+libcurl:
+- '7'
 mpi:
 - openmpi
+openssl:
+- 1.1.1
 pin_run_as_build:
+  libcurl:
+    max_pin: x
+  openssl:
+    max_pin: x.x.x
   zlib:
     max_pin: x.x
 target_platform:

--- a/.ci_support/linux_ppc64le_mpimpich.yaml
+++ b/.ci_support/linux_ppc64le_mpimpich.yaml
@@ -16,9 +16,17 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '8'
+libcurl:
+- '7'
 mpi:
 - mpich
+openssl:
+- 1.1.1
 pin_run_as_build:
+  libcurl:
+    max_pin: x
+  openssl:
+    max_pin: x.x.x
   zlib:
     max_pin: x.x
 target_platform:

--- a/.ci_support/linux_ppc64le_mpinompi.yaml
+++ b/.ci_support/linux_ppc64le_mpinompi.yaml
@@ -16,9 +16,17 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '8'
+libcurl:
+- '7'
 mpi:
 - nompi
+openssl:
+- 1.1.1
 pin_run_as_build:
+  libcurl:
+    max_pin: x
+  openssl:
+    max_pin: x.x.x
   zlib:
     max_pin: x.x
 target_platform:

--- a/.ci_support/linux_ppc64le_mpiopenmpi.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpi.yaml
@@ -16,9 +16,17 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '8'
+libcurl:
+- '7'
 mpi:
 - openmpi
+openssl:
+- 1.1.1
 pin_run_as_build:
+  libcurl:
+    max_pin: x
+  openssl:
+    max_pin: x.x.x
   zlib:
     max_pin: x.x
 target_platform:

--- a/.ci_support/osx_64_mpimpich.yaml
+++ b/.ci_support/osx_64_mpimpich.yaml
@@ -16,13 +16,21 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+libcurl:
+- '7'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
 mpi:
 - mpich
+openssl:
+- 1.1.1
 pin_run_as_build:
+  libcurl:
+    max_pin: x
+  openssl:
+    max_pin: x.x.x
   zlib:
     max_pin: x.x
 target_platform:

--- a/.ci_support/osx_64_mpinompi.yaml
+++ b/.ci_support/osx_64_mpinompi.yaml
@@ -16,13 +16,21 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+libcurl:
+- '7'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
 mpi:
 - nompi
+openssl:
+- 1.1.1
 pin_run_as_build:
+  libcurl:
+    max_pin: x
+  openssl:
+    max_pin: x.x.x
   zlib:
     max_pin: x.x
 target_platform:

--- a/.ci_support/osx_64_mpiopenmpi.yaml
+++ b/.ci_support/osx_64_mpiopenmpi.yaml
@@ -16,13 +16,21 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+libcurl:
+- '7'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
 mpi:
 - openmpi
+openssl:
+- 1.1.1
 pin_run_as_build:
+  libcurl:
+    max_pin: x
+  openssl:
+    max_pin: x.x.x
   zlib:
     max_pin: x.x
 target_platform:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -6,9 +6,17 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2017
+libcurl:
+- '7'
 mpi:
 - nompi
+openssl:
+- 1.1.1
 pin_run_as_build:
+  libcurl:
+    max_pin: x
+  openssl:
+    max_pin: x.x.x
   zlib:
     max_pin: x.x
 target_platform:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -37,7 +37,7 @@ fi
             --enable-unsupported \
             --enable-using-memchecker \
             --enable-static=yes \
-            --enable-ros3-vfd \
+            --enable-ros3-vfd
 
 # allow oversubscribing with openmpi in make check
 export OMPI_MCA_rmaps_base_oversubscribe=yes

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -42,6 +42,9 @@ fi
 # allow oversubscribing with openmpi in make check
 export OMPI_MCA_rmaps_base_oversubscribe=yes
 
+if [[ "$CI" != "travis" ]]; then
+  make -j "${CPU_COUNT}" ${VERBOSE_AT}
+else
 # using || to quiet logs unless there is an issue
 {
     # see this https://github.com/travis-ci/travis-ci/issues/4190#issuecomment-353342526
@@ -55,4 +58,4 @@ export OMPI_MCA_rmaps_base_oversubscribe=yes
     tail -n 5000 make_logs.txt
     exit 1
 }
-
+fi

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -37,6 +37,7 @@ fi
             --enable-unsupported \
             --enable-using-memchecker \
             --enable-static=yes \
+            --enable-ros3-vfd \
 
 # allow oversubscribing with openmpi in make check
 export OMPI_MCA_rmaps_base_oversubscribe=yes

--- a/recipe/install.sh
+++ b/recipe/install.sh
@@ -1,4 +1,4 @@
-make install
+make install V=1
 
 if [[ ${mpi} == "openmpi" && "$(uname)" == "Darwin" ]]; then
   # ph5diff hangs on darwin with openmpi, skip the test

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "1.12.0" %}
 {% set maj_min_ver = ".".join(version.split(".")[:2]) %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'nompi' %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,9 +70,13 @@ requirements:
   host:
     - {{ mpi }}  # [mpi != 'nompi']
     - zlib
+    - libcurl
+    - openssl
   run:
     - {{ mpi }}  # [mpi != 'nompi']
     - zlib
+    - libcurl
+    - openssl
 
 outputs:
   - name: hdf5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -100,9 +100,13 @@ outputs:
       host:
         - {{ mpi }}  # [mpi != 'nompi']
         - zlib
+        - libcurl
+        - openssl
       run:
         - {{ mpi }}  # [mpi != 'nompi']
         - zlib
+        - libcurl
+        - openssl
 
     test:
       requires:


### PR DESCRIPTION
The whole point of #122 was to play with the new read-only S3 VFD functionality of HDF5 1.12. Apparently I forgot to check if it actually got enabled by default (it doesn't). This PR enables the feature and as far as I know does not have any additional requirements or effect any other features of the library since it should be a libcurl-based contact to a remote S3 storage. More info here:

https://portal.hdfgroup.org/display/HDF5/Configuration+and+Setup+for+HDF5+Read+Only+S3+VFD

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
