### PR TITLE
Enable osx-arm64 cross-compile build of HDF5 1.12

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -17,6 +17,15 @@ jobs:
       osx_64_mpiopenmpi:
         CONFIG: osx_64_mpiopenmpi
         UPLOAD_PACKAGES: 'True'
+      osx_arm64_mpimpich:
+        CONFIG: osx_arm64_mpimpich
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_mpinompi:
+        CONFIG: osx_arm64_mpinompi
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_mpiopenmpi:
+        CONFIG: osx_arm64_mpiopenmpi
+        UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/osx_arm64_mpimpich.yaml
+++ b/.ci_support/osx_arm64_mpimpich.yaml
@@ -1,0 +1,41 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge/label/rust_dev,conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '11'
+libcurl:
+- '7'
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpi:
+- mpich
+openssl:
+- 1.1.1
+pin_run_as_build:
+  libcurl:
+    max_pin: x
+  openssl:
+    max_pin: x.x.x
+  zlib:
+    max_pin: x.x
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+zlib:
+- '1.2'

--- a/.ci_support/osx_arm64_mpinompi.yaml
+++ b/.ci_support/osx_arm64_mpinompi.yaml
@@ -1,0 +1,41 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge/label/rust_dev,conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '11'
+libcurl:
+- '7'
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpi:
+- nompi
+openssl:
+- 1.1.1
+pin_run_as_build:
+  libcurl:
+    max_pin: x
+  openssl:
+    max_pin: x.x.x
+  zlib:
+    max_pin: x.x
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+zlib:
+- '1.2'

--- a/.ci_support/osx_arm64_mpiopenmpi.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpi.yaml
@@ -1,0 +1,41 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge/label/rust_dev,conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '11'
+libcurl:
+- '7'
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpi:
+- openmpi
+openssl:
+- 1.1.1
+pin_run_as_build:
+  libcurl:
+    max_pin: x
+  openssl:
+    max_pin: x.x.x
+  zlib:
+    max_pin: x.x
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+zlib:
+- '1.2'

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -29,6 +29,10 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+     EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+fi
+
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -48,6 +48,10 @@ set -e
 echo -e "\n\nMaking the build clobber file and running the build."
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
 
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+fi
+
 conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml ${EXTRA_CB_OPTIONS:-}
 validate_recipe_outputs "${FEEDSTOCK_NAME}"
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,27 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>osx_arm64_mpimpich</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=412&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hdf5-feedstock?branchName=master&jobName=osx&configuration=osx_arm64_mpimpich" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mpinompi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=412&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hdf5-feedstock?branchName=master&jobName=osx&configuration=osx_arm64_mpinompi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mpiopenmpi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=412&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hdf5-feedstock?branchName=master&jobName=osx&configuration=osx_arm64_mpiopenmpi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>win_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=412&branchName=master">

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,6 @@
-provider: {linux_aarch64: default, linux_ppc64le: azure, win: azure}
-conda_forge_output_validation: true
 bot:
-  abi_migration_branches:
-    - 1.10.x
+  abi_migration_branches: [1.10.x]
+build_platform: {osx_arm64: osx_64}
+conda_forge_output_validation: true
+provider: {linux_aarch64: default, linux_ppc64le: azure, win: azure}
+test_on_native_only: true

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,3 +1,5 @@
+# Get an updated config.sub and config.guess
+cp $BUILD_PREFIX/share/gnuconfig/config.* ./bin
 
 #!/bin/bash
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,12 +1,19 @@
-# Get an updated config.sub and config.guess
-cp $BUILD_PREFIX/share/gnuconfig/config.* ./bin
-
 #!/bin/bash
+
+# Get an updated config.sub and config.guess
+cp $BUILD_PREFIX/share/libtool/build-aux/config.* ./bin
+
 
 export LIBRARY_PATH="${PREFIX}/lib"
 
 if [[ ! -z "$mpi" && "$mpi" != "nompi" ]]; then
   export CONFIGURE_ARGS="--enable-parallel ${CONFIGURE_ARGS}"
+
+  if [[ "$CONDA_BUILD_CROSS_COMPILATION" == 1 ]]; then
+    mkdir -p $BUILD_PREFIX/share/${mpi}/
+    cp -rf $PREFIX/share/${mpi}/*.txt $BUILD_PREFIX/share/${mpi}/
+  fi
+
   export CC=mpicc
   export CXX=mpic++
   export FC=mpifort
@@ -24,6 +31,35 @@ else
   export FC=$(basename ${FC})
 fi
 
+if [[ "$CONDA_BUILD_CROSS_COMPILATION" == 1 && $target_platform == "osx-arm64" ]]; then
+  export ac_cv_sizeof_long_double=8
+  export hdf5_cv_ldouble_to_long_special=no
+  export hdf5_cv_long_to_ldouble_special=no
+  export hdf5_cv_ldouble_to_llong_accurate=yes
+  export hdf5_cv_llong_to_ldouble_correct=yes
+  export hdf5_cv_disable_some_ldouble_conv=no
+  export hdf5_cv_system_scope_threads=yes
+  export hdf5_cv_printf_ll="l"
+  export PAC_FC_MAX_REAL_PRECISION=15
+  export PAC_C_MAX_REAL_PRECISION=17
+  export PAC_FC_ALL_INTEGER_KINDS="{1,2,4,8,16}"
+  export PAC_FC_ALL_REAL_KINDS="{4,8}"
+  export H5CONFIG_F_NUM_RKIND="INTEGER, PARAMETER :: num_rkinds = 2"
+  export H5CONFIG_F_NUM_IKIND="INTEGER, PARAMETER :: num_ikinds = 5"
+  export H5CONFIG_F_RKIND="INTEGER, DIMENSION(1:num_rkinds) :: rkind = (/4,8/)"
+  export H5CONFIG_F_IKIND="INTEGER, DIMENSION(1:num_ikinds) :: ikind = (/1,2,4,8,16/)"
+  export PAC_FORTRAN_NATIVE_INTEGER_SIZEOF="                    4"
+  export PAC_FORTRAN_NATIVE_INTEGER_KIND="           4"
+  export PAC_FORTRAN_NATIVE_REAL_SIZEOF="                    4"
+  export PAC_FORTRAN_NATIVE_REAL_KIND="           4"
+  export PAC_FORTRAN_NATIVE_DOUBLE_SIZEOF="                    8"
+  export PAC_FORTRAN_NATIVE_DOUBLE_KIND="           8"
+  export PAC_FORTRAN_NUM_INTEGER_KINDS="5"
+  export PAC_FC_ALL_REAL_KINDS_SIZEOF="{4,8}"
+  export PAC_FC_ALL_INTEGER_KINDS_SIZEOF="{1,2,4,8,16}"
+  export hdf5_disable_tests="--enable-tests=no"
+fi
+
 ./configure --prefix="${PREFIX}" \
             ${CONFIGURE_ARGS} \
             --with-pic \
@@ -39,10 +75,32 @@ fi
             --enable-unsupported \
             --enable-using-memchecker \
             --enable-static=yes \
-            --enable-ros3-vfd
+            --enable-ros3-vfd \
+	    ${hdf5_disable_tests}
 
 # allow oversubscribing with openmpi in make check
 export OMPI_MCA_rmaps_base_oversubscribe=yes
+
+if [[ "$CONDA_BUILD_CROSS_COMPILATION" == 1 ]]; then
+  (
+    # Make a native build of the hdetect and H5make_libsettings executables
+    mkdir -p native-build/bin
+    pushd native-build/bin
+
+    $CC_FOR_BUILD ../../src/H5detect.c -I ../../src/ -o H5detect
+    $CC_FOR_BUILD ../../src/H5make_libsettings.c -I ../../src/ -o H5make_libsettings
+    $CC_FOR_BUILD ../../fortran/src/H5match_types.c -I ../../src/ -o H5match_types
+    # When building on osx-64 fortran is confused by 11.0
+    if [[ "$build_platform" == "osx-64" ]]; then
+      export MACOSX_DEPLOYMENT_TARGET=10.15
+    fi
+    $FC_FOR_BUILD ../../fortran/src/H5_buildiface.F90 -I ../../fortran/src/ -L $BUILD_PREFIX/lib -o H5_buildiface
+    $FC_FOR_BUILD ../../hl/fortran/src/H5HL_buildiface.F90 -I ../../hl/fortran/src -I ../../fortran/src -L $BUILD_PREFIX/lib -o H5HL_buildiface
+
+    popd
+  )
+  export PATH=`pwd`/native-build/bin:$PATH
+fi
 
 if [[ "$CI" != "travis" ]]; then
   make -j "${CPU_COUNT}" ${VERBOSE_AT}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,20 +10,26 @@ export LIBRARY_PATH="${PREFIX}/lib"
 if [[ ! -z "$mpi" && "$mpi" != "nompi" ]]; then
   export CONFIGURE_ARGS="--enable-parallel ${CONFIGURE_ARGS}"
 
-  if [[ "$mpi" == "openmpi" ]]; then
-    rm $PREFIX/bin/opal_wrapper
-    echo '#!/bin/bash' > $PREFIX/bin/opal_wrapper
-    echo "export OPAL_PREFIX=$PREFIX" >> $PREFIX/bin/opal_wrapper
-    echo "$BUILD_PREFIX/bin/\$(basename \"\$0\") \"\$@\"" >> $PREFIX/bin/opal_wrapper
-    chmod +x $PREFIX/bin/opal_wrapper
-  fi
-
   export CC=$PREFIX/bin/mpicc
   export CXX=$PREFIX/bin/mpic++
   export FC=$PREFIX/bin/mpifort
-  export CC_FOR_BUILD=$BUILD_PREFIX/bin/mpicc
-  export CXX_FOR_BUILD=$BUILD_PREFIX/bin/mpic++
-  export FC_FOR_BUILD=$BUILD_PREFIX/bin/mpifort
+
+  if [[ "$CONDA_BUILD_CROSS_COMPILATION" == "1" ]]; then
+    if [[ "$mpi" == "openmpi" ]]; then
+      rm $PREFIX/bin/opal_wrapper
+      echo '#!/bin/bash' > $PREFIX/bin/opal_wrapper
+      echo "export OPAL_PREFIX=$PREFIX" >> $PREFIX/bin/opal_wrapper
+      echo "$BUILD_PREFIX/bin/\$(basename \"\$0\") \"\$@\"" >> $PREFIX/bin/opal_wrapper
+      chmod +x $PREFIX/bin/opal_wrapper
+    fi
+    export CC_FOR_BUILD=$BUILD_PREFIX/bin/mpicc
+    export CXX_FOR_BUILD=$BUILD_PREFIX/bin/mpic++
+    export FC_FOR_BUILD=$BUILD_PREFIX/bin/mpifort
+  else
+    export CC_FOR_BUILD=$PREFIX/bin/mpicc
+    export CXX_FOR_BUILD=$PREFIX/bin/mpic++
+    export FC_FOR_BUILD=$PREFIX/bin/mpifort
+  fi
 
   if [[ "$target_platform" == linux-* ]]; then
     # --as-needed appears to cause problems with fortran compiler detection

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,6 +63,7 @@ build:
 
 requirements:
   build:
+    - gnuconfig  # [unix]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('fortran') }}  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "1.12.0" %}
 {% set maj_min_ver = ".".join(version.split(".")[:2]) %}
-{% set build = 3 %}
+{% set build = 5 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'nompi' %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,6 +55,11 @@ source:
     # Fix for curl>7.69
     # See https://github.com/conda-forge/hdf5-feedstock/issues/125
     - patches/fix_curl_nobody.patch
+    # Enable cross-compiling on osx
+    - patches/osx_cross_configure.patch  # [osx and build_platform != target_platform]
+    - patches/osx_cross_src_makefile.patch  # [osx and build_platform != target_platform]
+    - patches/osx_cross_fortran_src_makefile.patch  # [osx and build_platform != target_platform]
+    - patches/osx_cross_hl_fortran_src_makefile.patch  # [osx and build_platform != target_platform]
 
 build:
   number: {{ build }}
@@ -71,6 +76,8 @@ requirements:
     - libtool                    # [not win]
     - make                       # [not win]
     - ninja                      # [win]
+    - {{ mpi }}  # [build_platform != target_platform and mpi != 'nompi']
+    - libgfortran-devel_osx-64  # [build_platform != target_platform and build_platform == 'osx-64']
   host:
     - {{ mpi }}  # [mpi != 'nompi']
     - zlib
@@ -101,6 +108,7 @@ outputs:
         - libtool  # [not win]
         - make                       # [not win]
         - ninja  # [win]
+        - {{ mpi }}  # [build_platform != target_platform and mpi != 'nompi']
       host:
         - {{ mpi }}  # [mpi != 'nompi']
         - zlib

--- a/recipe/patches/osx_cross_configure.patch
+++ b/recipe/patches/osx_cross_configure.patch
@@ -1,0 +1,218 @@
+--- configure.orig	2020-12-29 22:11:02.000000000 -0800
++++ configure	2020-12-29 22:14:27.000000000 -0800
+@@ -667,6 +667,7 @@
+ DEPRECATED_SYMBOLS
+ BUILD_ALL_CONDITIONAL_FALSE
+ BUILD_ALL_CONDITIONAL_TRUE
++cross_compiling
+ ROOT
+ JAVA_VERSION
+ CXX_VERSION
+@@ -6423,12 +6424,7 @@
+ }
+ 
+ _ACEOF
+-        if test "$cross_compiling" = yes; then :
+-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+-as_fn_error $? "cannot run test program while cross compiling
+-See \`config.log' for more details" "$LINENO" 5; }
+-else
++if test "$cross_compiling" = no; then :
+   if ac_fn_c_try_run "$LINENO"; then :
+ 
+             if test -s pac_Cconftest.out ; then
+@@ -6452,13 +6448,15 @@
+ 
+ 
+ 
+-if test "$ac_cv_sizeof___float128" != 0 && test "$FLT128_DIG" != 0 ; then
++if [ -z "$PAC_C_MAX_REAL_PRECISION" ]; then
++  if test "$ac_cv_sizeof___float128" != 0 && test "$FLT128_DIG" != 0 ; then
+ 
+ $as_echo "#define HAVE_FLOAT128 1" >>confdefs.h
+ 
+-  PAC_C_MAX_REAL_PRECISION=$FLT128_DIG
+-else
+-  PAC_C_MAX_REAL_PRECISION=$LDBL_DIG
++    PAC_C_MAX_REAL_PRECISION=$FLT128_DIG
++  else
++    PAC_C_MAX_REAL_PRECISION=$LDBL_DIG
++  fi
+ fi
+ 
+ cat >>confdefs.h <<_ACEOF
+@@ -7924,10 +7922,32 @@
+ rm -f pac_fconftest.out
+ TEST_SRC="`sed -n '/PROGRAM FC_AVAIL_KINDS/,/END PROGRAM FC_AVAIL_KINDS/p' $srcdir/m4/aclocal_fc.f90`"
+ if test "$cross_compiling" = yes; then :
+-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+-as_fn_error $? "cannot run test program while cross compiling
+-See \`config.log' for more details" "$LINENO" 5; }
++
++cat >>confdefs.h <<_ACEOF
++#define PAC_FC_MAX_REAL_PRECISION $PAC_FC_MAX_REAL_PRECISION
++_ACEOF
++
++
++cat >>confdefs.h <<_ACEOF
++#define H5CONFIG_F_NUM_RKIND $H5CONFIG_F_NUM_RKIND
++_ACEOF
++
++
++cat >>confdefs.h <<_ACEOF
++#define H5CONFIG_F_NUM_IKIND $H5CONFIG_F_NUM_IKIND
++_ACEOF
++
++
++cat >>confdefs.h <<_ACEOF
++#define H5CONFIG_F_RKIND $H5CONFIG_F_RKIND
++_ACEOF
++
++
++cat >>confdefs.h <<_ACEOF
++#define H5CONFIG_F_IKIND $H5CONFIG_F_IKIND
++_ACEOF
++
++
+ else
+   cat > conftest.$ac_ext <<_ACEOF
+ $TEST_SRC
+@@ -8093,101 +8113,6 @@
+ ac_link='$FC -o conftest$ac_exeext $FCFLAGS $LDFLAGS $ac_fcflags_srcext conftest.$ac_ext $LIBS >&5'
+ ac_compiler_gnu=$ac_cv_fc_compiler_gnu
+ 
+-rm -f pac_fconftest.out
+-TEST_SRC="`sed -n '/PROGRAM FC_AVAIL_KINDS/,/END PROGRAM FC_AVAIL_KINDS/p' $srcdir/m4/aclocal_fc.f90`"
+-if test "$cross_compiling" = yes; then :
+-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+-as_fn_error $? "cannot run test program while cross compiling
+-See \`config.log' for more details" "$LINENO" 5; }
+-else
+-  cat > conftest.$ac_ext <<_ACEOF
+-$TEST_SRC
+-_ACEOF
+-if ac_fn_fc_try_run "$LINENO"; then :
+-
+-    if test -s pac_fconftest.out ; then
+-
+-
+-        pac_validIntKinds="`sed -n '1p' pac_fconftest.out`"
+-	pac_validRealKinds="`sed -n '2p' pac_fconftest.out`"
+-        PAC_FC_MAX_REAL_PRECISION="`sed -n '3p' pac_fconftest.out`"
+-
+-cat >>confdefs.h <<_ACEOF
+-#define PAC_FC_MAX_REAL_PRECISION $PAC_FC_MAX_REAL_PRECISION
+-_ACEOF
+-
+-
+-        PAC_FC_ALL_INTEGER_KINDS="{`echo $pac_validIntKinds`}"
+-        PAC_FC_ALL_REAL_KINDS="{`echo $pac_validRealKinds`}"
+-
+-        PAC_FORTRAN_NUM_INTEGER_KINDS="`sed -n '4p' pac_fconftest.out`"
+-	H5CONFIG_F_NUM_IKIND="INTEGER, PARAMETER :: num_ikinds = `echo $PAC_FORTRAN_NUM_INTEGER_KINDS`"
+-	H5CONFIG_F_IKIND="INTEGER, DIMENSION(1:num_ikinds) :: ikind = (/`echo $pac_validIntKinds`/)"
+-	H5CONFIG_F_NUM_RKIND="INTEGER, PARAMETER :: num_rkinds = `sed -n '5p' pac_fconftest.out`"
+-	H5CONFIG_F_RKIND="INTEGER, DIMENSION(1:num_rkinds) :: rkind = (/`echo $pac_validRealKinds`/)"
+-
+-
+-cat >>confdefs.h <<_ACEOF
+-#define H5CONFIG_F_NUM_RKIND $H5CONFIG_F_NUM_RKIND
+-_ACEOF
+-
+-
+-cat >>confdefs.h <<_ACEOF
+-#define H5CONFIG_F_NUM_IKIND $H5CONFIG_F_NUM_IKIND
+-_ACEOF
+-
+-
+-cat >>confdefs.h <<_ACEOF
+-#define H5CONFIG_F_RKIND $H5CONFIG_F_RKIND
+-_ACEOF
+-
+-
+-cat >>confdefs.h <<_ACEOF
+-#define H5CONFIG_F_IKIND $H5CONFIG_F_IKIND
+-_ACEOF
+-
+-
+-        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Number of Fortran INTEGER KINDs" >&5
+-$as_echo_n "checking for Number of Fortran INTEGER KINDs... " >&6; }
+-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PAC_FORTRAN_NUM_INTEGER_KINDS" >&5
+-$as_echo "$PAC_FORTRAN_NUM_INTEGER_KINDS" >&6; }
+-        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Fortran INTEGER KINDs" >&5
+-$as_echo_n "checking for Fortran INTEGER KINDs... " >&6; }
+-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PAC_FC_ALL_INTEGER_KINDS" >&5
+-$as_echo "$PAC_FC_ALL_INTEGER_KINDS" >&6; }
+-	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for Fortran REAL KINDs" >&5
+-$as_echo_n "checking for Fortran REAL KINDs... " >&6; }
+-	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $PAC_FC_ALL_REAL_KINDS" >&5
+-$as_echo "$PAC_FC_ALL_REAL_KINDS" >&6; }
+-	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for Fortran REALs maximum decimal precision" >&5
+-$as_echo_n "checking for Fortran REALs maximum decimal precision... " >&6; }
+-	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $PAC_FC_MAX_REAL_PRECISION" >&5
+-$as_echo "$PAC_FC_MAX_REAL_PRECISION" >&6; }
+-    else
+-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: Error" >&5
+-$as_echo "Error" >&6; }
+-        as_fn_error $? "No output from Fortran test program!" "$LINENO" 5
+-    fi
+-    rm -f pac_fconftest.out
+-
+-else
+-
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: Error" >&5
+-$as_echo "Error" >&6; }
+-    as_fn_error $? "Failed to run Fortran program to determine available KINDs" "$LINENO" 5
+-
+-fi
+-rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+-  conftest.$ac_objext conftest.beam conftest.$ac_ext
+-fi
+-
+-
+-ac_ext=${ac_fc_srcext-f}
+-ac_compile='$FC -c $FCFLAGS $ac_fcflags_srcext conftest.$ac_ext >&5'
+-ac_link='$FC -o conftest$ac_exeext $FCFLAGS $LDFLAGS $ac_fcflags_srcext conftest.$ac_ext $LIBS >&5'
+-ac_compiler_gnu=$ac_cv_fc_compiler_gnu
+-
+ 
+   ## Find all sizeofs for available KINDs
+ 
+@@ -8242,7 +8167,9 @@
+ fi
+ 
+ done
+-PAC_FC_ALL_INTEGER_KINDS_SIZEOF="{`echo $pack_int_sizeof | sed -e 's/,$//' | sed -e 's/ //g'`}"
++if [ -z "$PAC_FC_ALL_INTEGER_KINDS_SIZEOF" ]; then
++  PAC_FC_ALL_INTEGER_KINDS_SIZEOF="{`echo $pack_int_sizeof | sed -e 's/,$//' | sed -e 's/ //g'`}"
++fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PAC_FC_ALL_INTEGER_KINDS_SIZEOF" >&5
+ $as_echo "$PAC_FC_ALL_INTEGER_KINDS_SIZEOF" >&6; }
+ ac_ext=${ac_fc_srcext-f}
+@@ -8302,7 +8229,9 @@
+ fi
+ 
+ done
+-PAC_FC_ALL_REAL_KINDS_SIZEOF="{`echo $pack_real_sizeof | sed -e 's/,$//' | sed -e 's/ //g'`}"
++if [ -z "$PAC_FC_ALL_REAL_KINDS_SIZEOF" ]; then
++  PAC_FC_ALL_REAL_KINDS_SIZEOF="{`echo $pack_real_sizeof | sed -e 's/,$//' | sed -e 's/ //g'`}"
++fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PAC_FC_ALL_REAL_KINDS_SIZEOF" >&5
+ $as_echo "$PAC_FC_ALL_REAL_KINDS_SIZEOF" >&6; }
+ ac_ext=${ac_fc_srcext-f}
+@@ -31443,8 +31372,10 @@
+ 
+ if test "$cross_compiling" = yes; then :
+ 
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: unknown, assuming yes" >&5
+-$as_echo "unknown, assuming yes" >&6; }
++    { $as_echo "$as_me:${as_lineno-$LINENO}: result: unknown, assuming no" >&5
++$as_echo "unknown, assuming no" >&6; }
++
++$as_echo "#define NO_ALIGNMENT_RESTRICTIONS 1" >>confdefs.h
+ 
+ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext

--- a/recipe/patches/osx_cross_fortran_src_makefile.patch
+++ b/recipe/patches/osx_cross_fortran_src_makefile.patch
@@ -1,0 +1,33 @@
+--- fortran/src/Makefile.in.orig	2020-12-29 22:16:43.000000000 -0800
++++ fortran/src/Makefile.in	2020-12-29 22:18:01.000000000 -0800
+@@ -114,6 +114,14 @@
+ # pass the -static flag to the library linker.
+ @FORTRAN_SHARED_CONDITIONAL_FALSE@am__append_1 = -static
+ noinst_PROGRAMS = H5match_types$(EXEEXT) H5_buildiface$(EXEEXT)
++
++cross_compiling = @cross_compiling@
++ifeq ($(cross_compiling),yes)
++  src_run = 
++else
++  src_run = ./
++endif
++
+ TESTS =
+ subdir = fortran/src
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+@@ -1453,13 +1461,13 @@
+ # header, then H5match_types which includes that header, then
+ # it needs to run H5match_types.
+ H5fortran_types.F90 H5f90i_gen.h: H5match_types$(EXEEXT)
+-	$(RUNSERIAL) ./H5match_types$(EXEEXT)
++	$(RUNSERIAL) $(src_run)H5match_types$(EXEEXT)
+ 
+ # H5_buildiface.F90 generates all the APIs that have a KIND type associated
+ # with them.
+ 
+ H5_gen.F90: H5_buildiface$(EXEEXT)
+-	$(RUNSERIAL) ./H5_buildiface$(EXEEXT)
++	$(RUNSERIAL) $(src_run)H5_buildiface$(EXEEXT)
+ 
+ # Hardcode the dependencies of these files. There isn't a known way of
+ # determining this automagically (like we do with the C files). So, when

--- a/recipe/patches/osx_cross_hl_fortran_src_makefile.patch
+++ b/recipe/patches/osx_cross_hl_fortran_src_makefile.patch
@@ -1,0 +1,26 @@
+--- hl/fortran/src/Makefile.in.orig	2020-12-29 22:18:21.000000000 -0800
++++ hl/fortran/src/Makefile.in	2020-12-29 22:19:37.000000000 -0800
+@@ -114,6 +114,14 @@
+ # pass the -static flag to the library linker.
+ @FORTRAN_SHARED_CONDITIONAL_FALSE@am__append_1 = -static
+ noinst_PROGRAMS = H5HL_buildiface$(EXEEXT)
++
++cross_compiling = @cross_compiling@
++ifeq ($(cross_compiling),yes)
++  src_run = 
++else
++  src_run = ./
++endif
++
+ TESTS =
+ subdir = hl/fortran/src
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+@@ -1394,7 +1402,7 @@
+ # with them.
+ 
+ H5LTff_gen.F90: H5HL_buildiface$(EXEEXT)
+-	$(RUNSERIAL) ./H5HL_buildiface$(EXEEXT)
++	$(RUNSERIAL) $(src_run)H5HL_buildiface$(EXEEXT)
+ 
+ H5TBff_gen.F90: H5HL_buildiface$(EXEEXT)
+ # Hardcode the dependencies of these files. There isn't a known way of

--- a/recipe/patches/osx_cross_src_makefile.patch
+++ b/recipe/patches/osx_cross_src_makefile.patch
@@ -1,0 +1,34 @@
+--- src/Makefile.in.orig	2020-12-29 22:15:29.000000000 -0800
++++ src/Makefile.in	2020-12-29 22:16:23.000000000 -0800
+@@ -108,6 +108,13 @@
+ host_triplet = @host@
+ noinst_PROGRAMS = H5detect$(EXEEXT) H5make_libsettings$(EXEEXT)
+ 
++cross_compiling = @cross_compiling@
++ifeq ($(cross_compiling),yes)
++  src_run = 
++else
++  src_run = ./
++endif
++
+ # Only compile parallel sources if necessary
+ @BUILD_PARALLEL_CONDITIONAL_TRUE@am__append_1 = H5mpi.c H5ACmpio.c H5Cmpio.c H5Dmpio.c H5Fmpi.c H5FDmpi.c H5FDmpio.c H5Smpio.c
+ 
+@@ -1937,7 +1944,7 @@
+ H5Tinit.c: H5detect$(EXEEXT)
+ 	LD_LIBRARY_PATH="$$LD_LIBRARY_PATH`echo $(LDFLAGS) |                  \
+ 		sed -e 's/-L/:/g' -e 's/ //g'`"                               \
+-	$(RUNSERIAL) ./H5detect$(EXEEXT)  $@  ||                               \
++	$(RUNSERIAL) $(src_run)H5detect$(EXEEXT)  $@  ||                               \
+ 	    (test $$HDF5_Make_Ignore && echo "*** Error ignored") ||          \
+ 	    ($(RM) $@ ; exit 1)
+ 
+@@ -1949,7 +1956,7 @@
+ H5lib_settings.c: H5make_libsettings$(EXEEXT) libhdf5.settings
+ 	LD_LIBRARY_PATH="$$LD_LIBRARY_PATH`echo $(LDFLAGS) |                  \
+ 		sed -e 's/-L/:/g' -e 's/ //g'`"                               \
+-	$(RUNSERIAL) ./H5make_libsettings$(EXEEXT)  $@  ||                               \
++	$(RUNSERIAL) $(src_run)H5make_libsettings$(EXEEXT)  $@  ||                               \
+ 	    (test $$HDF5_Make_Ignore && echo "*** Error ignored") ||          \
+ 	    ($(RM) $@ ; exit 1)
+ 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
