### PR TITLE
Correct issue with string function

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -76,6 +76,7 @@ requirements:
     - ninja                      # [win]
     - {{ mpi }}  # [build_platform != target_platform and mpi != 'nompi']
     - libgfortran-devel_osx-64  # [build_platform != target_platform and build_platform == 'osx-64']
+    - binutils                   # [linux]
   host:
     - {{ mpi }}  # [mpi != 'nompi']
     - zlib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "1.12.0" %}
 {% set maj_min_ver = ".".join(version.split(".")[:2]) %}
-{% set build = 7 %}
+{% set build = 8 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'nompi' %}


### PR DESCRIPTION
This line corrects the issues with the string function in Linux systems.
The binutils dependency adds the missing functions needed to build the package.

This is a fix to issue #154 in the hdf5-feedstock
https://github.com/conda-forge/hdf5-feedstock/issues/154

<!--
Thank you for the pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
