### PR TITLE
Drop `1.10.x` branch from ABI migrations

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,3 @@
-bot:
-  abi_migration_branches: [1.10.x]
 build_platform: {osx_arm64: osx_64}
 conda_forge_output_validation: true
 provider: {linux_aarch64: azure, linux_ppc64le: azure}


### PR DESCRIPTION
The last non-bot change to the `1.10.x` branch was PR ( https://github.com/conda-forge/hdf5-feedstock/pull/148 ) from January 8, 2021 (2 years ago!). The rest of the bot changes are updating `conda-forge.yml`.

Globally [`hdf5` is pinned to `1.12.1`]( https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/6b4e0315359a2cb746418c53fa5c510e1c418818/recipe/conda_build_config.yaml#L393-L394 ).

Also the `1.10.x` branch is getting pinning migrations ( like OpenSSL 3 https://github.com/conda-forge/hdf5-feedstock/pull/168 ), which are holding up closing those out.

Given all this, think we should drop the `1.10.x` branch from ABI migrations.

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
