### PR TITLE
Change maintainer username from @astrofrog-conda-forge to @astrofrog

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -47,11 +47,6 @@ jobs:
   timeoutInMinutes: 360
 
   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -60,7 +60,10 @@ jobs:
         if EXIST LICENSE.txt (
           copy LICENSE.txt "recipe\\recipe-scripts-license.txt"
         )
-        conda.exe mambabuild "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables
+        if NOT [%HOST_PLATFORM%] == [%BUILD_PLATFORM%] (
+          set "EXTRA_CB_OPTIONS=%EXTRA_CB_OPTIONS% --no-test"
+        )
+        conda.exe mambabuild "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
       displayName: Build recipe
       env:
         PYTHONUNBUFFERED: 1

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @SylvainCorlay @astrofrog-conda-forge @davidbrochart @gillins @groutr @hmaarrfk @jakirkham @marcelotrevisani @marqh @ocefpaf @scopatz @varlackc
+* @SylvainCorlay @astrofrog @davidbrochart @gillins @groutr @hmaarrfk @jakirkham @marcelotrevisani @marqh @ocefpaf @scopatz @varlackc

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -55,11 +55,6 @@ source run_conda_forge_build_setup
 echo -e "\n\nMaking the build clobber file"
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
 
-if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
-    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
-fi
-
-
 if [[ -f LICENSE.txt ]]; then
   cp LICENSE.txt "recipe/recipe-scripts-license.txt"
 fi
@@ -75,6 +70,11 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
+
+    if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+    fi
+
     conda mambabuild ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About hdf5-feedstock
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/hdf5-feedstock/blob/main/LICENSE.txt)
 
-Home: http://www.hdfgroup.org/HDF5/
+Home: https://www.hdfgroup.org/solutions/hdf5/
 
 Package license: LicenseRef-HDF5
 
@@ -272,7 +272,7 @@ Feedstock Maintainers
 =====================
 
 * [@SylvainCorlay](https://github.com/SylvainCorlay/)
-* [@astrofrog-conda-forge](https://github.com/astrofrog-conda-forge/)
+* [@astrofrog](https://github.com/astrofrog/)
 * [@davidbrochart](https://github.com/davidbrochart/)
 * [@gillins](https://github.com/gillins/)
 * [@groutr](https://github.com/groutr/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -179,7 +179,7 @@ extra:
     - gillins
     - groutr
     - ocefpaf
-    - astrofrog-conda-forge
+    - astrofrog
     - marqh
     - marcelotrevisani
     - scopatz


### PR DESCRIPTION
This is to update my username from @astrofrog-conda-forge to @astrofrog - I used to have a separate username back when being a member of any conda-forge repository meant that I saw all conda-forge repositories on Travis CI but this is no longer relevant.

@conda-forge-admin please rerender