### PR TITLE
Backport c++ fix

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "1.14.4" %}
 {% set maj_min_ver = ".".join(version.split(".")[:2]) %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'nompi' %}
@@ -51,6 +51,8 @@ source:
     # Enable cross-compiling on osx
     - patches/0001-avoid-test-execution-when-cross-compiling.patch  # [osx and build_platform != target_platform]
     - patches/0002-run-host-H5detect-when-cross-compiling.patch     # [osx and build_platform != target_platform]
+    # Fix operator= (https://github.com/HDFGroup/hdf5/pull/4473)
+    - patches/ea760136.patch
 
 build:
   number: {{ build }}

--- a/recipe/patches/ea760136.patch
+++ b/recipe/patches/ea760136.patch
@@ -1,0 +1,41 @@
+From ea76013648aac81cee941a7b7a86f21201d1debf Mon Sep 17 00:00:00 2001
+From: Julien Schueller <schueller@phimeca.com>
+Date: Fri, 10 May 2024 23:30:19 +0200
+Subject: [PATCH] H5Group: Fix operator= (#4473)
+
+Closes #4472
+---
+ c++/src/H5Attribute.cpp | 4 +---
+ c++/src/H5Group.cpp     | 4 +---
+ 2 files changed, 2 insertions(+), 6 deletions(-)
+
+diff --git a/c++/src/H5Attribute.cpp b/c++/src/H5Attribute.cpp
+index e629a800c76..a79d7c3a024 100644
+--- a/c++/src/H5Attribute.cpp
++++ b/c++/src/H5Attribute.cpp
+@@ -610,9 +610,7 @@ Attribute::~Attribute()
+ Attribute &
+ Attribute::operator=(const Attribute &original)
+ {
+-    if (&original != this) {
+-        setId(original.id);
+-    }
++    IdComponent::operator=(original);
+ 
+     return *this;
+ }
+diff --git a/c++/src/H5Group.cpp b/c++/src/H5Group.cpp
+index 248e71f9571..48358b3a5cb 100644
+--- a/c++/src/H5Group.cpp
++++ b/c++/src/H5Group.cpp
+@@ -279,9 +279,7 @@ Group::~Group()
+ Group &
+ Group::operator=(const Group &original)
+ {
+-    if (&original != this) {
+-        setId(original.id);
+-    }
++    IdComponent::operator=(original);
+ 
+     return *this;
+ }


### PR DESCRIPTION
backports https://github.com/HDFGroup/hdf5/pull/4473 to fix a regression in the c++ layer (H5Group::operator= not handling exceptions)
Else the new version crashes for us

@conda-forge-admin please rerender