### PR TITLE
avoid exposing improper transitive dependency on zlib

### DIFF
--- a/recipe/6347-static-find-dependency.patch
+++ b/recipe/6347-static-find-dependency.patch
@@ -1,0 +1,22 @@
+diff --git a/config/install/hdf5-config.cmake.in b/config/install/hdf5-config.cmake.in
+index bb9a8d60f0..3b24a040e3 100644
+--- a/config/install/hdf5-config.cmake.in
++++ b/config/install/hdf5-config.cmake.in
+@@ -124,7 +124,7 @@ else ()
+   endif ()
+ endif ()
+ 
+-if (${HDF5_PACKAGE_NAME}_PROVIDES_ZLIB_SUPPORT)
++if (${HDF5_PACKAGE_NAME}_PROVIDES_ZLIB_SUPPORT AND ${HDF5_PACKAGE_NAME}_PROVIDES_STATIC_LIBS)
+   if (NOT @ZLIB_USE_EXTERNAL@)
+     if (@HDF5_MODULE_MODE_ZLIB@)
+       # Expect that the default shared library is expected with FindZLIB.cmake
+@@ -135,7 +135,7 @@ if (${HDF5_PACKAGE_NAME}_PROVIDES_ZLIB_SUPPORT)
+   endif ()
+ endif ()
+ 
+-if (${HDF5_PACKAGE_NAME}_PROVIDES_SZIP_SUPPORT)
++if (${HDF5_PACKAGE_NAME}_PROVIDES_SZIP_SUPPORT AND ${HDF5_PACKAGE_NAME}_PROVIDES_STATIC_LIBS)
+   if (NOT @SZIP_USE_EXTERNAL@)
+     find_dependency (@LIBAEC_PACKAGE_NAME@ OPTIONAL_COMPONENTS @LIBAEC_SEARCH_TYPE@)
+   endif ()

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "2.1.0" %}
 {% set maj_min_patch_ver = "_".join(version.split(".")) %}
 {% set maj_min_ver = "_".join(version.split(".")[:2]) %}
-{% set build = 3 %}
+{% set build = 4 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'nompi' %}
@@ -50,6 +50,9 @@ source:
     # https://github.com/HDFGroup/hdf5/pull/6324
     - 6324-fix-data-alignment-requirements-check-in-diect-io-vfd.diff
 
+    # https://github.com/HDFGroup/hdf5/issues/6347
+    - 6347-static-find-dependency.patch
+
 build:
   number: {{ build }}
   string: {{ mpi_prefix }}_h{{ PKG_HASH }}_{{ build }}
@@ -97,8 +100,6 @@ test:
     - pkg-config                 # [not win]
     - cmake                      # [not win]
     - make                       # [not win]
-    # Need zlib to compile test programs
-    - zlib
     # ensure new libgfortran is co-installable; in July 2025, there were resolution errors
     # with hdfs5 depending on `libgfortran =5` (either real or hallucinated). This check can
     # be dropped again in 1-3 years if the issue does not keep recurring in the meantime.


### PR DESCRIPTION
zlib shouldn't be required to link hdf5, but there's a `find_dependency` call in hdf5 cmake that I think shouldn't be there, leading to find_package(hdf5) failing if zlib dev files aren't present.

upstream issue: https://github.com/HDFGroup/hdf5/issues/6347

I haven't submitted a PR upstream because I'm not sure the logic here is correct for every hdf5 install (Windows, static, etc.), but I believe it is for ours (shared only)